### PR TITLE
Change the InMemDb to use a PriorityQueue to organize file byte[] chunks

### DIFF
--- a/app/src/main/java/tftpserver/core/TFTPDataChunk.java
+++ b/app/src/main/java/tftpserver/core/TFTPDataChunk.java
@@ -1,0 +1,19 @@
+package tftpserver.core;
+
+import lombok.Getter;
+
+public class TFTPDataChunk implements Comparable<TFTPDataChunk>{
+    private final Short blockNumber;
+    @Getter
+    private final byte[] data;
+
+    public TFTPDataChunk(Short blockNumber, byte[] data) {
+        this.blockNumber = blockNumber;
+        this.data = data;
+    }
+
+    @Override
+    public int compareTo(TFTPDataChunk o) {
+        return Short.compare(o.blockNumber, this.blockNumber);
+    }
+}

--- a/app/src/main/java/tftpserver/db/Db.java
+++ b/app/src/main/java/tftpserver/db/Db.java
@@ -1,5 +1,7 @@
 package tftpserver.db;
 
+import tftpserver.core.TFTPDataChunk;
+
 import java.io.FileNotFoundException;
 import java.util.List;
 
@@ -21,8 +23,7 @@ public interface Db {
      *                  ...
      *                 [<512] String (Block `n`)
      */
-    void saveFile(String filename, List<byte[]> content);
-
+    void saveFile(String filename, List<TFTPDataChunk> content);
 
     /**
      * Given a filename, return the contents of it as a List<byte[]>

--- a/app/src/main/java/tftpserver/handlers/PutHandler.java
+++ b/app/src/main/java/tftpserver/handlers/PutHandler.java
@@ -2,6 +2,7 @@ package tftpserver.handlers;
 
 import lombok.extern.java.Log;
 import tftpserver.PacketHelper;
+import tftpserver.core.TFTPDataChunk;
 import tftpserver.db.InMemDb;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ public class PutHandler implements DataTransferHandler {
 
         // Handle to hold the byte arrays that define the contents
         // of the file.
-        List<byte[]> fileContents = new ArrayList<>();
+        List<TFTPDataChunk> fileContents = new ArrayList<>();
 
         // Step 1: Send an ACK Packet to the client to let it know what port to use
         //         to send the data packets to. Also indicates that the server at
@@ -82,7 +83,10 @@ public class PutHandler implements DataTransferHandler {
                 }
 
                 dataSize = dataBytes.position();
-                fileContents.add(Arrays.copyOfRange(dataBytes.array(), 0, dataSize));
+                fileContents.add(new TFTPDataChunk(
+                        blockNumber,
+                        Arrays.copyOfRange(dataBytes.array(), 0, dataSize)
+                ));
 
                 PacketHelper.sendAck(blockNumber, sock, clientAddress);
             } while (dataSize >= 512);


### PR DESCRIPTION
Previously, the datastructure used a List to store the file byte[]
chunks that were recieved from the network. This lacked a crucial point
- there was no ordering of the data chunks by block numbers. To solve
  this problem, the change implements an Abstraction thats comparable
  and encapsulates the contents of a data chunk.
- Now on, all the packets (irrespective of the order they're got it) are
  inserted into the priority queue and the queue takes care of sorting
  them based on the block numbers.

Resolves #4